### PR TITLE
Add libopenblas-dev to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN \
     libnng-dev \
     libopenbabel-dev \
     libopenblas0 \
+    libopenblas-dev \
     libopencv-dev \
     libopenmpi-dev \
     libpng-dev \


### PR DESCRIPTION
This is a requirement for building my Rmlx package, and it seems likely to be useful for many packages. The package is only ~18Kb so unlikely to be too demanding.