### PR TITLE
Fix R version extraction in Rprofile

### DIFF
--- a/Rprofile
+++ b/Rprofile
@@ -1,6 +1,6 @@
 # Repositories
 local({
-  r_branch <- substr(getRversion(), 1, 3)
+  r_branch <- sub('^(\\d+\\.\\d+).*', '\\1', getRversion())
   distro <- system2('lsb_release', '-sc', stdout = TRUE)
   binary_universe <- function(universe){
     sprintf("%s/bin/linux/%s-%s/%s", universe, distro, R.version$arch, r_branch)


### PR DESCRIPTION
The minor version number can be more than 1 digit (e.g., 2.15.2: https://cran.r-project.org/src/base/R-2/), so regex should be more robust here.